### PR TITLE
All employee pages card are hidden (cutting) from right side

### DIFF
--- a/packages/css/src/pages/employee/index.scss
+++ b/packages/css/src/pages/employee/index.scss
@@ -129,7 +129,7 @@
     .main {
       padding-top: 80px;
       margin-left: 88px;
-      width: 100%;
+      width: auto;
     }
   }
 


### PR DESCRIPTION
## Before
![Screenshot 2021-02-26 160555](https://user-images.githubusercontent.com/75667085/109289704-96ee9d80-784c-11eb-94cc-1bbc6daca5f0.png)
![Screenshot 2021-02-26 160607](https://user-images.githubusercontent.com/75667085/109289710-9bb35180-784c-11eb-8db3-67d3d3d7e170.png)

## After
![Screenshot 2021-02-26 160313](https://user-images.githubusercontent.com/75667085/109289719-9f46d880-784c-11eb-9c22-d6ea857866b7.png)
![Screenshot 2021-02-26 160325](https://user-images.githubusercontent.com/75667085/109289734-a372f600-784c-11eb-84b0-c6d8cf9bf134.png)


