### PR TITLE
add shipping truck icon and add fsm title for mobile screen

### DIFF
--- a/packages/modules/fsm/src/components/inbox/ApplicationLinks.js
+++ b/packages/modules/fsm/src/components/inbox/ApplicationLinks.js
@@ -1,4 +1,4 @@
-import { Card } from "@egovernments/digit-ui-react-components";
+import { Card, ShippingTruck } from "@egovernments/digit-ui-react-components";
 import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
@@ -54,12 +54,9 @@ const ApplicationLinks = () => {
   const GetLogo = () => (
     <div className="header">
       <span className="logo">
-        <svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">
-          <path d="M0 0h24v24H0z" fill="none" />
-          <path d="M20 2H4c-1.1 0-1.99.9-1.99 2L2 22l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-7 9h-2V5h2v6zm0 4h-2v-2h2v2z" fill="white" />
-        </svg>
+        <ShippingTruck />
       </span>{" "}
-      <span className="text">Applications</span>
+      <span className="text">{t("ES_TITLE_FAECAL_SLUDGE_MGMT")}</span>
     </div>
   );
 

--- a/packages/modules/fsm/src/components/inbox/FSMLink.js
+++ b/packages/modules/fsm/src/components/inbox/FSMLink.js
@@ -1,4 +1,4 @@
-import { Card } from "@egovernments/digit-ui-react-components";
+import { Card, ShippingTruck } from "@egovernments/digit-ui-react-components";
 import { forEach } from "lodash";
 import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
@@ -54,10 +54,7 @@ const FSMLink = ({ isMobile, data }) => {
   const GetLogo = () => (
     <div className="header">
       <span className="logo">
-        <svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">
-          <path d="M0 0h24v24H0z" fill="none" />
-          <path d="M20 2H4c-1.1 0-1.99.9-1.99 2L2 22l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-7 9h-2V5h2v6zm0 4h-2v-2h2v2z" fill="white" />
-        </svg>
+        <ShippingTruck />
       </span>{" "}
       <span className="text">{t("ES_TITLE_FAECAL_SLUDGE_MGMT")}</span>
     </div>


### PR DESCRIPTION
## Before
![Screenshot 2021-03-05 172019](https://user-images.githubusercontent.com/75667085/110112077-412f6d80-7dd7-11eb-83dd-f4b43e16747f.png)
![Screenshot 2021-03-05 172040](https://user-images.githubusercontent.com/75667085/110112080-42609a80-7dd7-11eb-948f-31b83534b834.png)

## After
![Screenshot 2021-03-05 171823](https://user-images.githubusercontent.com/75667085/110112094-45f42180-7dd7-11eb-8199-468d54641944.png)
![Screenshot 2021-03-05 171840](https://user-images.githubusercontent.com/75667085/110112096-45f42180-7dd7-11eb-83ee-6a711940095e.png)
