### PR TITLE
add download pdf instead of open pdf

### DIFF
--- a/packages/libraries/src/utils/pdf.js
+++ b/packages/libraries/src/utils/pdf.js
@@ -74,7 +74,7 @@ const jsPdfGenerator = async ({ tenantId, logo, name, email, phoneNumber, headin
       },
     ],
   };
-  pdfMake.createPdf(dd).open();
+  pdfMake.createPdf(dd).download();
 };
 
 export default { generate: jsPdfGenerator };


### PR DESCRIPTION
Fix for Citizen APK - My Applications & Success screen :: Not able to download application acknowledgement pdf 