### PR TITLE
Fix able to download pdf by clicking next to Download button

### DIFF
--- a/packages/modules/fsm/src/pages/Response.js
+++ b/packages/modules/fsm/src/pages/Response.js
@@ -164,6 +164,7 @@ const Response = (props) => {
               <span className="download-button">{t("CS_COMMON_DOWNLOAD")}</span>
             </div>
           }
+          style={{ width: "100px" }}
           onClick={handleDownloadPdf}
         />
       )}

--- a/packages/modules/fsm/src/pages/citizen/NewApplication/Response.js
+++ b/packages/modules/fsm/src/pages/citizen/NewApplication/Response.js
@@ -99,6 +99,7 @@ const Response = ({ data, onSuccess }) => {
               <span className="download-button">{t("CS_COMMON_DOWNLOAD")}</span>
             </div>
           }
+          style={{ width: "100px" }}
           onClick={handleDownloadPdf}
         />
       )}


### PR DESCRIPTION
Citizen complaint success screen - Download button :: Able to download pdf by clicking next to Download button

Steps:
Create application from citizen
Download application from success screen and click anywhere in horizontal line from download button