### PR TITLE
showing search results when user come back from application details

### DIFF
--- a/packages/modules/fsm/src/Module.js
+++ b/packages/modules/fsm/src/Module.js
@@ -79,6 +79,15 @@ const FsmBreadCrumb = ({ location }) => {
 
 const EmployeeApp = ({ path, url, userType }) => {
   const location = useLocation();
+
+  useEffect(() => {
+    if (!location?.pathname?.includes("inbox")) {
+      Digit.SessionStorage.del("fsm/inbox/searchParams");
+    } else if (!location?.pathname?.includes("search")) {
+      Digit.SessionStorage.del("fsm/search/searchParams");
+    }
+  }, [location]);
+
   return (
     <Switch>
       <React.Fragment>

--- a/packages/modules/fsm/src/Module.js
+++ b/packages/modules/fsm/src/Module.js
@@ -81,10 +81,12 @@ const EmployeeApp = ({ path, url, userType }) => {
   const location = useLocation();
 
   useEffect(() => {
-    if (!location?.pathname?.includes("inbox")) {
-      Digit.SessionStorage.del("fsm/inbox/searchParams");
-    } else if (!location?.pathname?.includes("search")) {
-      Digit.SessionStorage.del("fsm/search/searchParams");
+    if (!location?.pathname?.includes("application-details")) {
+      if (!location?.pathname?.includes("inbox")) {
+        Digit.SessionStorage.del("fsm/inbox/searchParams");
+      } else if (!location?.pathname?.includes("search")) {
+        Digit.SessionStorage.del("fsm/search/searchParams");
+      }
     }
   }, [location]);
 

--- a/packages/modules/fsm/src/components/inbox/AssignedTo.js
+++ b/packages/modules/fsm/src/components/inbox/AssignedTo.js
@@ -21,16 +21,18 @@ const AssignedTo = ({ onFilterChange, searchParams, tenantId, t }) => {
     null
   );
 
+  const availableOptions = [
+    { code: "ASSIGNED_TO_ME", name: `${t("ES_INBOX_ASSIGNED_TO_ME")} (${AssignedToMe?.[0]?.totalCount || 0})` },
+    { code: "ASSIGNED_TO_ALL", name: `${t("ES_INBOX_ASSIGNED_TO_ALL")} (${AssignedToAll?.[0]?.totalCount || 0})` },
+  ];
+
   return (
     <React.Fragment>
       <RadioButtons
-        onSelect={(d) => onFilterChange({ uuid: d })}
-        selectedOption={searchParams?.uuid}
+        onSelect={(d) => onFilterChange({ uuid: { code: d.code } })}
+        selectedOption={availableOptions.filter((option) => option.code === searchParams?.uuid?.code)[0]}
         optionsKey="name"
-        options={[
-          { code: "ASSIGNED_TO_ME", name: `${t("ES_INBOX_ASSIGNED_TO_ME")} (${AssignedToMe?.[0]?.totalCount || 0})` },
-          { code: "ASSIGNED_TO_ALL", name: `${t("ES_INBOX_ASSIGNED_TO_ALL")} (${AssignedToAll?.[0]?.totalCount || 0})` },
-        ]}
+        options={availableOptions}
       />
     </React.Fragment>
   );

--- a/packages/modules/fsm/src/components/inbox/search.js
+++ b/packages/modules/fsm/src/components/inbox/search.js
@@ -28,6 +28,8 @@ const SearchApplication = ({ onSearch, type, onClose, isFstpOperator, searchFiel
   function clearSearch() {
     const resetValues = searchFields.reduce((acc, field) => ({ ...acc, [field?.name]: "" }), {});
     reset(resetValues);
+    Digit.SessionStorage.del("fsm/search/searchParams");
+    Digit.SessionStorage.del("fsm/inbox/searchParams");
     onSearch({});
   }
 

--- a/packages/modules/fsm/src/components/inbox/search.js
+++ b/packages/modules/fsm/src/components/inbox/search.js
@@ -4,13 +4,13 @@ import { TextInput, Label, SubmitBar, LinkLabel, ActionBar, CloseSvg, DatePicker
 import { useTranslation } from "react-i18next";
 
 const SearchApplication = ({ onSearch, type, onClose, isFstpOperator, searchFields, searchParams, isInboxPage }) => {
-  const searchParamsData =
-    searchParams || isInboxPage ? Digit.SessionStorage.get("fsm/inbox/searchParams") : Digit.SessionStorage.get("fsm/search/searchParams");
+  const storedSearchParams = isInboxPage ? Digit.SessionStorage.get("fsm/inbox/searchParams") : Digit.SessionStorage.get("fsm/search/searchParams");
+
   const { t } = useTranslation();
   const [applicationNo, setApplicationNo] = useState("");
   const [mobileNo, setMobileNo] = useState("");
   const { register, handleSubmit, reset, watch, control } = useForm({
-    defaultValues: searchParamsData,
+    defaultValues: storedSearchParams || searchParams,
   });
   const mobileView = innerWidth <= 640;
   const FSTP = Digit.UserService.hasAccess("FSM_EMP_FSTPO") || false;

--- a/packages/modules/fsm/src/components/inbox/search.js
+++ b/packages/modules/fsm/src/components/inbox/search.js
@@ -4,11 +4,13 @@ import { TextInput, Label, SubmitBar, LinkLabel, ActionBar, CloseSvg, DatePicker
 import { useTranslation } from "react-i18next";
 
 const SearchApplication = ({ onSearch, type, onClose, isFstpOperator, searchFields, searchParams, isInboxPage }) => {
+  const searchParamsData =
+    searchParams || isInboxPage ? Digit.SessionStorage.get("fsm/inbox/searchParams") : Digit.SessionStorage.get("fsm/search/searchParams");
   const { t } = useTranslation();
   const [applicationNo, setApplicationNo] = useState("");
   const [mobileNo, setMobileNo] = useState("");
   const { register, handleSubmit, reset, watch, control } = useForm({
-    defaultValues: searchParams,
+    defaultValues: searchParamsData,
   });
   const mobileView = innerWidth <= 640;
   const FSTP = Digit.UserService.hasAccess("FSM_EMP_FSTPO") || false;

--- a/packages/modules/fsm/src/components/inbox/search.js
+++ b/packages/modules/fsm/src/components/inbox/search.js
@@ -28,8 +28,11 @@ const SearchApplication = ({ onSearch, type, onClose, isFstpOperator, searchFiel
   function clearSearch() {
     const resetValues = searchFields.reduce((acc, field) => ({ ...acc, [field?.name]: "" }), {});
     reset(resetValues);
-    Digit.SessionStorage.del("fsm/search/searchParams");
-    Digit.SessionStorage.del("fsm/inbox/searchParams");
+    if (isInboxPage) {
+      Digit.SessionStorage.del("fsm/inbox/searchParams");
+    } else {
+      Digit.SessionStorage.del("fsm/search/searchParams");
+    }
     onSearch({});
   }
 

--- a/packages/modules/fsm/src/pages/employee/Inbox.js
+++ b/packages/modules/fsm/src/pages/employee/Inbox.js
@@ -119,16 +119,16 @@ const Inbox = ({ parentRoute, isSearch = false, isInbox = false }) => {
   useEffect(() => {
     if (isSearch) {
       if (Object.values(searchParams).length > 0) {
-        localStorage.setItem("fsm/search/searchParams", JSON.stringify(searchParams));
+        Digit.SessionStorage.set("fsm/search/searchParams", searchParams);
       } else {
-        const storedSearchParams = JSON.parse(localStorage.getItem("fsm/search/searchParams"));
+        const storedSearchParams = Digit.SessionStorage.get("fsm/search/searchParams");
         if (storedSearchParams) {
           setSearchParams(storedSearchParams);
           onSearch(storedSearchParams);
         }
       }
     } else {
-      localStorage.setItem("fsm/search/searchParams", null);
+      Digit.SessionStorage.set("fsm/search/searchParams", null);
     }
   }, [searchParams]);
 

--- a/packages/modules/fsm/src/pages/employee/Inbox.js
+++ b/packages/modules/fsm/src/pages/employee/Inbox.js
@@ -116,6 +116,22 @@ const Inbox = ({ parentRoute, isSearch = false, isInbox = false }) => {
     }
   };
 
+  useEffect(() => {
+    if (isSearch) {
+      if (Object.values(searchParams).length > 0) {
+        localStorage.setItem("fsm/search/searchParams", JSON.stringify(searchParams));
+      } else {
+        const storedSearchParams = JSON.parse(localStorage.getItem("fsm/search/searchParams"));
+        if (storedSearchParams) {
+          setSearchParams(storedSearchParams);
+          onSearch(storedSearchParams);
+        }
+      }
+    } else {
+      localStorage.setItem("fsm/search/searchParams", null);
+    }
+  }, [searchParams]);
+
   const removeParam = (params = {}) => {
     const _search = { ...searchParams };
     Object.keys(params).forEach((key) => delete _search[key]);

--- a/packages/modules/fsm/src/pages/employee/Inbox.js
+++ b/packages/modules/fsm/src/pages/employee/Inbox.js
@@ -116,19 +116,23 @@ const Inbox = ({ parentRoute, isSearch = false, isInbox = false }) => {
     }
   };
 
-  useEffect(() => {
-    if (isSearch) {
-      if (Object.values(searchParams).length > 0) {
-        Digit.SessionStorage.set("fsm/search/searchParams", searchParams);
-      } else {
-        const storedSearchParams = Digit.SessionStorage.get("fsm/search/searchParams");
-        if (storedSearchParams) {
-          setSearchParams(storedSearchParams);
-          onSearch(storedSearchParams);
-        }
-      }
+  const search = (condition = false, key, searchParams) => {
+    if (condition) {
+      Digit.SessionStorage.set(key, searchParams);
     } else {
-      Digit.SessionStorage.del("fsm/search/searchParams");
+      const storedSearchParams = Digit.SessionStorage.get(key);
+      if (storedSearchParams) {
+        onSearch(storedSearchParams);
+      }
+    }
+  };
+
+  useEffect(() => {
+    search();
+    if (isSearch) {
+      search(Object.values(searchParams).length > 0, "fsm/search/searchParams", searchParams);
+    } else if (isInbox) {
+      search(searchParams?.applicationNos || searchParams?.mobileNumber, "fsm/inbox/searchParams", searchParams);
     }
   }, [searchParams]);
 

--- a/packages/modules/fsm/src/pages/employee/Inbox.js
+++ b/packages/modules/fsm/src/pages/employee/Inbox.js
@@ -128,7 +128,7 @@ const Inbox = ({ parentRoute, isSearch = false, isInbox = false }) => {
         }
       }
     } else {
-      Digit.SessionStorage.set("fsm/search/searchParams", null);
+      Digit.SessionStorage.del("fsm/search/searchParams");
     }
   }, [searchParams]);
 

--- a/packages/modules/fsm/src/pages/employee/Inbox.js
+++ b/packages/modules/fsm/src/pages/employee/Inbox.js
@@ -20,18 +20,23 @@ const Inbox = ({ parentRoute, isSearch = false, isInbox = false }) => {
   const [pageOffset, setPageOffset] = useState(0);
   const [pageSize, setPageSize] = useState(10);
   const [sortParams, setSortParams] = useState([{ id: "createdTime", desc: false }]);
-  const [searchParams, setSearchParams] = useState(() => {
-    return isInbox
-      ? {
-          applicationStatus: [],
-          locality: [],
-          uuid:
-            DSO || isFSTPOperator
-              ? { code: "ASSIGNED_TO_ME", name: t("ES_INBOX_ASSIGNED_TO_ME") }
-              : { code: "ASSIGNED_TO_ALL", name: t("ES_INBOX_ASSIGNED_TO_ALL") },
-        }
-      : {};
-  });
+
+  const searchParamsKey = isInbox ? "fsm/inbox/searchParams" : "fsm/search/searchParams";
+  const searchParamsValue = isInbox
+    ? {
+        applicationStatus: [],
+        locality: [],
+        uuid:
+          DSO || isFSTPOperator
+            ? { code: "ASSIGNED_TO_ME", name: t("ES_INBOX_ASSIGNED_TO_ME") }
+            : { code: "ASSIGNED_TO_ALL", name: t("ES_INBOX_ASSIGNED_TO_ALL") },
+      }
+    : {};
+  const [searchParams, setSearchParams] = Digit.Hooks.useSessionStorage(searchParamsKey, searchParamsValue);
+
+  useEffect(() => {
+    onSearch(searchParams);
+  }, []);
 
   let isMobile = window.Digit.Utils.browser.isMobile();
   let paginationParms = isMobile
@@ -115,25 +120,6 @@ const Inbox = ({ parentRoute, isSearch = false, isInbox = false }) => {
       setSearchParams(({ applicationStatus, locality, uuid }) => ({ applicationStatus, locality, uuid, ...params }));
     }
   };
-
-  const search = (condition = false, key, searchParams) => {
-    if (condition) {
-      Digit.SessionStorage.set(key, searchParams);
-    } else {
-      const storedSearchParams = Digit.SessionStorage.get(key);
-      if (storedSearchParams) {
-        onSearch(storedSearchParams);
-      }
-    }
-  };
-
-  useEffect(() => {
-    if (isSearch) {
-      search(Object.values(searchParams).length > 0, "fsm/search/searchParams", searchParams);
-    } else if (isInbox) {
-      search(searchParams?.applicationNos || searchParams?.mobileNumber, "fsm/inbox/searchParams", searchParams);
-    }
-  }, [searchParams]);
 
   const removeParam = (params = {}) => {
     const _search = { ...searchParams };

--- a/packages/modules/fsm/src/pages/employee/Inbox.js
+++ b/packages/modules/fsm/src/pages/employee/Inbox.js
@@ -128,7 +128,6 @@ const Inbox = ({ parentRoute, isSearch = false, isInbox = false }) => {
   };
 
   useEffect(() => {
-    search();
     if (isSearch) {
       search(Object.values(searchParams).length > 0, "fsm/search/searchParams", searchParams);
     } else if (isInbox) {


### PR DESCRIPTION
https://digit-discuss.atlassian.net/browse/FSM-292
If from the application details page if the employee clicks on Search application - it has to redirect the user to the search result page with search intact. And from here user can select to view or take action on any other application.

## Before
https://files.slack.com/files-pri/T109J61DY-F01SXLSNY75/breadcrumbsnavigatingbackpagenotholdingdataissue.gif

## After
https://www.loom.com/share/e26125888e4848fab432d44e2ac962e0