### PR TITLE
RAIN-3092 TL :: Employee Digit Inbox :: In Figma, icons are for all modules are displayed on the right side of the card but in UI it's on left

### DIFF
--- a/packages/modules/tl/src/components/TLCard.js
+++ b/packages/modules/tl/src/components/TLCard.js
@@ -23,14 +23,14 @@ const TLCard = () => {
     return (
         <div className="employeeCard card-home" style={{ display: "inline-block" }}>
             <div className="complaint-links-container">
-                <div className="header">
+                <div className="header" style={{display: "flex", justifyContent:"space-between"}}>
+                    <span className="text">{t("ACTION_TEST_TRADELICENSE")}</span>
                     <span className="logo">
                         <svg width="24" height="24" viewBox="0 0 34 32" fill="none" xmlns="http://www.w3.org/2000/svg">
                             <path d="M30.3333 6.99967H23.6667V3.66634C23.6667 1.81634 22.1833 0.333008 20.3333 0.333008H13.6667C11.8167 0.333008 10.3333 1.81634 10.3333 3.66634V6.99967H3.66667C1.81667 6.99967 0.350001 8.48301 0.350001 10.333L0.333334 28.6663C0.333334 30.5163 1.81667 31.9997 3.66667 31.9997H30.3333C32.1833 31.9997 33.6667 30.5163 33.6667 28.6663V10.333C33.6667 8.48301 32.1833 6.99967 30.3333 6.99967ZM20.3333 6.99967H13.6667V3.66634H20.3333V6.99967Z" fill="white" />
                         </svg>
 
                     </span>
-                    <span className="text">{t("TL")}</span>
                 </div>
                 <div className="body" style={{ margin: "0px", padding: "0px" }}>
                     <div


### PR DESCRIPTION
RAIN-3092 TL :: Employee Digit Inbox :: In Figma, icons are for all modules are displayed on the right side of the card but in UI it's on left